### PR TITLE
Write username into log file to fix permission issues

### DIFF
--- a/winget-install.ps1
+++ b/winget-install.ps1
@@ -74,7 +74,7 @@ function Start-Init {
     }
 
     #Log file
-    $Script:LogFile = "$LogPath\install.log"
+    $Script:LogFile = "$LogPath\install_$env:UserName.log"
 
     #Log Header
     if ($Uninstall) {

--- a/winget-install.ps1
+++ b/winget-install.ps1
@@ -74,7 +74,12 @@ function Start-Init {
     }
 
     #Log file
-    $Script:LogFile = "$LogPath\install_$env:UserName.log"
+    if ([System.Security.Principal.WindowsIdentity]::GetCurrent().IsSystem) {
+        $Script:LogFile = "$LogPath\install.log"
+    }
+    else {
+        $Script:LogFile = "$LogPath\install_$env:UserName.log"
+    }
 
     #Log Header
     if ($Uninstall) {


### PR DESCRIPTION
We had an issue if a user installs a system application from Intune first (which creates the install.log file), and afterwards a user installed a app (Greenshot) in user context with Intune which then threw a permission error.
An easy fix (which also makes the logs better readable in my case) is to append a username to the log file name.

![image](https://user-images.githubusercontent.com/12374134/198555390-472d0713-9cf7-4527-9118-db8e27fa2be9.png)
